### PR TITLE
Add Azure OpenAI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Open http://localhost:5000 on browser of your choice to use Presenton.
 You may want to directly provide your API KEYS as environment variables and keep them hidden. You can set these environment variables to achieve it.
 
 - **CAN_CHANGE_KEYS=[true/false]**: Set this to **false** if you want to keep API Keys hidden and make them unmodifiable.
-- **LLM=[openai/google/ollama/custom]**: Select **LLM** of your choice.
+- **LLM=[openai/azure/google/ollama/custom]**: Select **LLM** of your choice.
 - **OPENAI_API_KEY=[Your OpenAI API Key]**: Provide this if **LLM** is set to **openai**
 - **GOOGLE_API_KEY=[Your Google API Key]**: Provide this if **LLM** is set to **google**
 - **OLLAMA_URL=[Custom Ollama URL]**: Provide this if you want to custom Ollama URL and **LLM** is set to **ollama**
@@ -71,10 +71,25 @@ You may want to directly provide your API KEYS as environment variables and keep
 - **CUSTOM_LLM_API_KEY=[Custom OpenAI Compatible API KEY]**: Provide this if **LLM** is set to **custom**
 - **CUSTOM_MODEL=[Custom Model ID]**: Provide this if **LLM** is set to **custom**
 - **PEXELS_API_KEY=[Your Pexels API Key]**: Provide this to generate images if **LLM** is set to **ollama** or **custom**
+- **AZURE_OPENAI_ENDPOINT=[Your Azure Endpoint]**: Provide this if **LLM** is set to **azure**
+- **AZURE_OPENAI_API_KEY=[Your Azure API Key]**: Provide this if **LLM** is set to **azure**
+- **AZURE_OPENAI_DEPLOYMENT=[Azure Deployment Name]**: Provide this if **LLM** is set to **azure**
+- **AZURE_OPENAI_API_VERSION=[Azure API Version]**: Optional API version for Azure
 
 ### Using OpenAI
 ```bash
 docker run -it --name presenton -p 5000:80 -e LLM="openai" -e OPENAI_API_KEY="******" -e CAN_CHANGE_KEYS="false" -v "./user_data:/app/user_data" ghcr.io/presenton/presenton:latest
+```
+
+### Using Azure OpenAI
+```bash
+docker run -it --name presenton -p 5000:80 \
+  -e LLM="azure" \
+  -e AZURE_OPENAI_ENDPOINT="https://YOUR_RESOURCE.openai.azure.com" \
+  -e AZURE_OPENAI_API_KEY="*****" \
+  -e AZURE_OPENAI_DEPLOYMENT="gpt-4" \
+  -e CAN_CHANGE_KEYS="false" \
+  -v "./user_data:/app/user_data" ghcr.io/presenton/presenton:latest
 ```
 
 ### Using Ollama

--- a/servers/fastapi/api/main.py
+++ b/servers/fastapi/api/main.py
@@ -28,6 +28,13 @@ async def check_llm_model_availability():
             if not openai_api_key:
                 raise Exception("OPENAI_API_KEY must be provided")
 
+        elif get_selected_llm_provider() == SelectedLLMProvider.AZURE:
+            endpoint = os.getenv("AZURE_OPENAI_ENDPOINT")
+            api_key = os.getenv("AZURE_OPENAI_API_KEY")
+            deployment = os.getenv("AZURE_OPENAI_DEPLOYMENT")
+            if not endpoint or not api_key or not deployment:
+                raise Exception("AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY and AZURE_OPENAI_DEPLOYMENT must be provided")
+
         elif get_selected_llm_provider() == SelectedLLMProvider.GOOGLE:
             google_api_key = os.getenv("GOOGLE_API_KEY")
             if not google_api_key:

--- a/servers/fastapi/api/models.py
+++ b/servers/fastapi/api/models.py
@@ -69,6 +69,10 @@ class UserConfig(BaseModel):
     CUSTOM_LLM_API_KEY: Optional[str] = None
     CUSTOM_MODEL: Optional[str] = None
     PEXELS_API_KEY: Optional[str] = None
+    AZURE_OPENAI_ENDPOINT: Optional[str] = None
+    AZURE_OPENAI_API_KEY: Optional[str] = None
+    AZURE_OPENAI_DEPLOYMENT: Optional[str] = None
+    AZURE_OPENAI_API_VERSION: Optional[str] = None
 
 
 class OllamaModelMetadata(BaseModel):
@@ -83,5 +87,6 @@ class OllamaModelMetadata(BaseModel):
 class SelectedLLMProvider(Enum):
     OLLAMA = "ollama"
     OPENAI = "openai"
+    AZURE = "azure"
     GOOGLE = "google"
     CUSTOM = "custom"

--- a/servers/fastapi/api/utils/model_utils.py
+++ b/servers/fastapi/api/utils/model_utils.py
@@ -4,7 +4,7 @@ from typing import AsyncGenerator, Optional
 
 import aiohttp
 from fastapi import HTTPException
-from openai import AsyncOpenAI
+from openai import AsyncOpenAI, AsyncAzureOpenAI
 import openai
 
 from api.models import SelectedLLMProvider
@@ -52,6 +52,8 @@ def get_model_base_url():
 
     if selected_llm == SelectedLLMProvider.OPENAI:
         return "https://api.openai.com/v1"
+    elif selected_llm == SelectedLLMProvider.AZURE:
+        return os.getenv("AZURE_OPENAI_ENDPOINT")
     elif selected_llm == SelectedLLMProvider.GOOGLE:
         return "https://generativelanguage.googleapis.com/v1beta/openai"
     elif selected_llm == SelectedLLMProvider.OLLAMA:
@@ -66,6 +68,8 @@ def get_llm_api_key():
     selected_llm = get_selected_llm_provider()
     if selected_llm == SelectedLLMProvider.OPENAI:
         return os.getenv("OPENAI_API_KEY")
+    elif selected_llm == SelectedLLMProvider.AZURE:
+        return os.getenv("AZURE_OPENAI_API_KEY")
     elif selected_llm == SelectedLLMProvider.GOOGLE:
         return os.getenv("GOOGLE_API_KEY")
     elif selected_llm == SelectedLLMProvider.OLLAMA:
@@ -77,10 +81,19 @@ def get_llm_api_key():
 
 
 def get_llm_client():
-    client = AsyncOpenAI(
-        base_url=get_model_base_url(),
-        api_key=get_llm_api_key(),
-    )
+    selected_llm = get_selected_llm_provider()
+    if selected_llm == SelectedLLMProvider.AZURE:
+        client = AsyncAzureOpenAI(
+            api_key=os.getenv("AZURE_OPENAI_API_KEY"),
+            azure_endpoint=os.getenv("AZURE_OPENAI_ENDPOINT"),
+            azure_deployment=os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+            api_version=os.getenv("AZURE_OPENAI_API_VERSION", "2024-02-15-preview"),
+        )
+    else:
+        client = AsyncOpenAI(
+            base_url=get_model_base_url(),
+            api_key=get_llm_api_key(),
+        )
     return client
 
 
@@ -88,6 +101,8 @@ def get_large_model():
     selected_llm = get_selected_llm_provider()
     if selected_llm == SelectedLLMProvider.OPENAI:
         return "gpt-4.1"
+    elif selected_llm == SelectedLLMProvider.AZURE:
+        return os.getenv("AZURE_OPENAI_DEPLOYMENT")
     elif selected_llm == SelectedLLMProvider.GOOGLE:
         return "gemini-2.0-flash"
     elif selected_llm == SelectedLLMProvider.OLLAMA:
@@ -102,6 +117,8 @@ def get_small_model():
     selected_llm = get_selected_llm_provider()
     if selected_llm == SelectedLLMProvider.OPENAI:
         return "gpt-4.1-mini"
+    elif selected_llm == SelectedLLMProvider.AZURE:
+        return os.getenv("AZURE_OPENAI_DEPLOYMENT")
     elif selected_llm == SelectedLLMProvider.GOOGLE:
         return "gemini-2.0-flash"
     elif selected_llm == SelectedLLMProvider.OLLAMA:
@@ -116,6 +133,8 @@ def get_nano_model():
     selected_llm = get_selected_llm_provider()
     if selected_llm == SelectedLLMProvider.OPENAI:
         return "gpt-4.1-nano"
+    elif selected_llm == SelectedLLMProvider.AZURE:
+        return os.getenv("AZURE_OPENAI_DEPLOYMENT")
     elif selected_llm == SelectedLLMProvider.GOOGLE:
         return "gemini-2.0-flash"
     elif selected_llm == SelectedLLMProvider.OLLAMA:

--- a/servers/fastapi/api/utils/utils.py
+++ b/servers/fastapi/api/utils/utils.py
@@ -51,6 +51,10 @@ def get_user_config():
         or os.getenv("CUSTOM_LLM_API_KEY"),
         CUSTOM_MODEL=existing_config.CUSTOM_MODEL or os.getenv("CUSTOM_MODEL"),
         PEXELS_API_KEY=existing_config.PEXELS_API_KEY or os.getenv("PEXELS_API_KEY"),
+        AZURE_OPENAI_ENDPOINT=existing_config.AZURE_OPENAI_ENDPOINT or os.getenv("AZURE_OPENAI_ENDPOINT"),
+        AZURE_OPENAI_API_KEY=existing_config.AZURE_OPENAI_API_KEY or os.getenv("AZURE_OPENAI_API_KEY"),
+        AZURE_OPENAI_DEPLOYMENT=existing_config.AZURE_OPENAI_DEPLOYMENT or os.getenv("AZURE_OPENAI_DEPLOYMENT"),
+        AZURE_OPENAI_API_VERSION=existing_config.AZURE_OPENAI_API_VERSION or os.getenv("AZURE_OPENAI_API_VERSION"),
     )
 
 
@@ -74,6 +78,14 @@ def update_env_with_user_config():
         os.environ["CUSTOM_MODEL"] = user_config.CUSTOM_MODEL
     if user_config.PEXELS_API_KEY:
         os.environ["PEXELS_API_KEY"] = user_config.PEXELS_API_KEY
+    if user_config.AZURE_OPENAI_ENDPOINT:
+        os.environ["AZURE_OPENAI_ENDPOINT"] = user_config.AZURE_OPENAI_ENDPOINT
+    if user_config.AZURE_OPENAI_API_KEY:
+        os.environ["AZURE_OPENAI_API_KEY"] = user_config.AZURE_OPENAI_API_KEY
+    if user_config.AZURE_OPENAI_DEPLOYMENT:
+        os.environ["AZURE_OPENAI_DEPLOYMENT"] = user_config.AZURE_OPENAI_DEPLOYMENT
+    if user_config.AZURE_OPENAI_API_VERSION:
+        os.environ["AZURE_OPENAI_API_VERSION"] = user_config.AZURE_OPENAI_API_VERSION
 
 
 def get_resource(relative_path):

--- a/servers/nextjs/app/api/user-config/route.ts
+++ b/servers/nextjs/app/api/user-config/route.ts
@@ -43,6 +43,10 @@ export async function POST(request: Request) {
     CUSTOM_MODEL: userConfig.CUSTOM_MODEL || existingConfig.CUSTOM_MODEL,
     PEXELS_API_KEY: userConfig.PEXELS_API_KEY || existingConfig.PEXELS_API_KEY,
     USE_CUSTOM_URL: userConfig.USE_CUSTOM_URL === undefined ? existingConfig.USE_CUSTOM_URL : userConfig.USE_CUSTOM_URL,
+    AZURE_OPENAI_ENDPOINT: userConfig.AZURE_OPENAI_ENDPOINT || existingConfig.AZURE_OPENAI_ENDPOINT,
+    AZURE_OPENAI_API_KEY: userConfig.AZURE_OPENAI_API_KEY || existingConfig.AZURE_OPENAI_API_KEY,
+    AZURE_OPENAI_DEPLOYMENT: userConfig.AZURE_OPENAI_DEPLOYMENT || existingConfig.AZURE_OPENAI_DEPLOYMENT,
+    AZURE_OPENAI_API_VERSION: userConfig.AZURE_OPENAI_API_VERSION || existingConfig.AZURE_OPENAI_API_VERSION,
   }
   fs.writeFileSync(userConfigPath, JSON.stringify(mergedConfig))
   return NextResponse.json(mergedConfig)

--- a/servers/nextjs/app/settings/SettingPage.tsx
+++ b/servers/nextjs/app/settings/SettingPage.tsx
@@ -32,6 +32,11 @@ const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
         description: "Required for using OpenAI services",
         placeholder: "Enter your OpenAI API key",
     },
+    azure: {
+        title: "Azure OpenAI Configuration",
+        description: "Endpoint, API Key and Deployment name",
+        placeholder: "Enter your Azure API key",
+    },
     google: {
         title: "Google API Key",
         description: "Required for using Google services",
@@ -99,6 +104,14 @@ const SettingsPage = () => {
             setLlmConfig({ ...llmConfig, CUSTOM_MODEL: new_value });
         } else if (field === 'pexels_api_key') {
             setLlmConfig({ ...llmConfig, PEXELS_API_KEY: new_value });
+        } else if (field === 'azure_endpoint') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_ENDPOINT: new_value });
+        } else if (field === 'azure_api_key') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_API_KEY: new_value });
+        } else if (field === 'azure_deployment') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_DEPLOYMENT: new_value });
+        } else if (field === 'azure_api_version') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_API_VERSION: new_value });
         }
     }
 
@@ -337,7 +350,7 @@ const SettingsPage = () => {
                         </div>
 
                         {/* API Key Input */}
-                        {llmConfig.LLM !== 'ollama' && llmConfig.LLM !== 'custom' && (
+                        {llmConfig.LLM !== 'ollama' && llmConfig.LLM !== 'custom' && llmConfig.LLM !== 'azure' && (
                             <div className="space-y-6">
                                 <div>
                                     <label className="block text-sm font-medium text-gray-700 mb-2">
@@ -353,6 +366,47 @@ const SettingsPage = () => {
                                         />
                                     </div>
                                     <p className="mt-2 text-sm text-gray-500">{PROVIDER_CONFIGS[llmConfig.LLM!].description}</p>
+                                </div>
+                            </div>
+                        )}
+
+                        {llmConfig.LLM === 'azure' && (
+                            <div className="space-y-6">
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">Azure Endpoint</label>
+                                    <input
+                                        type="text"
+                                        className="w-full px-4 py-2.5 border border-gray-300 outline-none rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                        value={llmConfig.AZURE_OPENAI_ENDPOINT || ''}
+                                        onChange={(e) => input_field_changed(e.target.value, 'azure_endpoint')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">Azure API Key</label>
+                                    <input
+                                        type="text"
+                                        className="w-full px-4 py-2.5 border border-gray-300 outline-none rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                        value={llmConfig.AZURE_OPENAI_API_KEY || ''}
+                                        onChange={(e) => input_field_changed(e.target.value, 'azure_api_key')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">Deployment Name</label>
+                                    <input
+                                        type="text"
+                                        className="w-full px-4 py-2.5 border border-gray-300 outline-none rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                        value={llmConfig.AZURE_OPENAI_DEPLOYMENT || ''}
+                                        onChange={(e) => input_field_changed(e.target.value, 'azure_deployment')}
+                                    />
+                                </div>
+                                <div>
+                                    <label className="block text-sm font-medium text-gray-700 mb-2">API Version</label>
+                                    <input
+                                        type="text"
+                                        className="w-full px-4 py-2.5 border border-gray-300 outline-none rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                        value={llmConfig.AZURE_OPENAI_API_VERSION || ''}
+                                        onChange={(e) => input_field_changed(e.target.value, 'azure_api_version')}
+                                    />
                                 </div>
                             </div>
                         )}

--- a/servers/nextjs/components/Home.tsx
+++ b/servers/nextjs/components/Home.tsx
@@ -84,6 +84,33 @@ const PROVIDER_CONFIGS: Record<string, ProviderConfig> = {
             docsUrl: "https://platform.openai.com/docs/api-reference/authentication",
         },
     },
+    azure: {
+        textModels: [
+            {
+                value: "azure-openai",
+                label: "Azure OpenAI",
+                description: "Azure hosted OpenAI model",
+                icon: "/icons/openai.png",
+                size: "8GB",
+            },
+        ],
+        imageModels: [
+            {
+                value: "dall-e-3",
+                label: "DALL-E 3",
+                description: "Latest version with highest quality",
+                icon: "/icons/dall-e.png",
+                size: "8GB",
+            },
+        ],
+        apiGuide: {
+            title: "Configure Azure OpenAI",
+            steps: [
+                "Provide endpoint, API key and deployment name",
+            ],
+            docsUrl: "https://learn.microsoft.com/azure/ai-services/openai/",
+        },
+    },
     google: {
         textModels: [
             {
@@ -206,6 +233,14 @@ export default function Home() {
             setLlmConfig({ ...llmConfig, CUSTOM_MODEL: new_value });
         } else if (field === 'pexels_api_key') {
             setLlmConfig({ ...llmConfig, PEXELS_API_KEY: new_value });
+        } else if (field === 'azure_endpoint') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_ENDPOINT: new_value });
+        } else if (field === 'azure_api_key') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_API_KEY: new_value });
+        } else if (field === 'azure_deployment') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_DEPLOYMENT: new_value });
+        } else if (field === 'azure_api_version') {
+            setLlmConfig({ ...llmConfig, AZURE_OPENAI_API_VERSION: new_value });
         }
     }
 
@@ -425,7 +460,7 @@ export default function Home() {
                     </div>
 
                     {/* API Key Input */}
-                    {llmConfig.LLM !== 'ollama' && llmConfig.LLM !== 'custom' && <div className="mb-8">
+                    {llmConfig.LLM !== 'ollama' && llmConfig.LLM !== 'custom' && llmConfig.LLM !== 'azure' && <div className="mb-8">
                         <label className="block text-sm font-medium text-gray-700 mb-2">
                             {llmConfig.LLM!.charAt(0).toUpperCase() +
                                 llmConfig.LLM!.slice(1)}{" "}
@@ -445,6 +480,46 @@ export default function Home() {
                             Your API key will be stored locally and never shared
                         </p>
                     </div>}
+                    {llmConfig.LLM === 'azure' && (
+                        <div className="mb-8 space-y-4">
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">Azure Endpoint</label>
+                                <input
+                                    type="text"
+                                    value={llmConfig.AZURE_OPENAI_ENDPOINT || ''}
+                                    onChange={(e) => input_field_changed(e.target.value, 'azure_endpoint')}
+                                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">Azure API Key</label>
+                                <input
+                                    type="text"
+                                    value={llmConfig.AZURE_OPENAI_API_KEY || ''}
+                                    onChange={(e) => input_field_changed(e.target.value, 'azure_api_key')}
+                                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">Deployment Name</label>
+                                <input
+                                    type="text"
+                                    value={llmConfig.AZURE_OPENAI_DEPLOYMENT || ''}
+                                    onChange={(e) => input_field_changed(e.target.value, 'azure_deployment')}
+                                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                />
+                            </div>
+                            <div>
+                                <label className="block text-sm font-medium text-gray-700 mb-2">API Version</label>
+                                <input
+                                    type="text"
+                                    value={llmConfig.AZURE_OPENAI_API_VERSION || ''}
+                                    onChange={(e) => input_field_changed(e.target.value, 'azure_api_version')}
+                                    className="w-full px-4 py-2.5 outline-none border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500/20 focus:border-blue-500 transition-colors"
+                                />
+                            </div>
+                        </div>
+                    )}
                     {
                         llmConfig.LLM === 'ollama' && (<div>
                             <div className="mb-8">

--- a/servers/nextjs/types/global.d.ts
+++ b/servers/nextjs/types/global.d.ts
@@ -23,6 +23,10 @@ interface LLMConfig {
   CUSTOM_LLM_API_KEY?: string;
   CUSTOM_MODEL?: string;
   PEXELS_API_KEY?: string;
+  AZURE_OPENAI_ENDPOINT?: string;
+  AZURE_OPENAI_API_KEY?: string;
+  AZURE_OPENAI_DEPLOYMENT?: string;
+  AZURE_OPENAI_API_VERSION?: string;
 
   // Only used in UI settings
   USE_CUSTOM_URL?: boolean;

--- a/servers/nextjs/utils/storeHelpers.ts
+++ b/servers/nextjs/utils/storeHelpers.ts
@@ -18,14 +18,20 @@ export const hasValidLLMConfig = (llmConfig: LLMConfig) => {
   if (!llmConfig.LLM) return false;
   const OPENAI_API_KEY = llmConfig.OPENAI_API_KEY;
   const GOOGLE_API_KEY = llmConfig.GOOGLE_API_KEY;
+  const AZURE_API_KEY = llmConfig.AZURE_OPENAI_API_KEY;
+  const AZURE_ENDPOINT = llmConfig.AZURE_OPENAI_ENDPOINT;
+  const AZURE_DEPLOYMENT = llmConfig.AZURE_OPENAI_DEPLOYMENT;
 
   const isOllamaConfigValid = llmConfig.OLLAMA_MODEL !== '' && llmConfig.OLLAMA_MODEL !== null && llmConfig.OLLAMA_MODEL !== undefined && llmConfig.OLLAMA_URL !== '' && llmConfig.OLLAMA_URL !== null && llmConfig.OLLAMA_URL !== undefined;
   const isCustomConfigValid = llmConfig.CUSTOM_LLM_URL !== '' && llmConfig.CUSTOM_LLM_URL !== null && llmConfig.CUSTOM_LLM_URL !== undefined && llmConfig.CUSTOM_MODEL !== '' && llmConfig.CUSTOM_MODEL !== null && llmConfig.CUSTOM_MODEL !== undefined;
 
   return llmConfig.LLM === 'openai' ?
     OPENAI_API_KEY !== '' && OPENAI_API_KEY !== null && OPENAI_API_KEY !== undefined :
-    llmConfig.LLM === 'google' ?
-      GOOGLE_API_KEY !== '' && GOOGLE_API_KEY !== null && GOOGLE_API_KEY !== undefined :
-      llmConfig.LLM === 'ollama' ? isOllamaConfigValid :
-        llmConfig.LLM === 'custom' ? isCustomConfigValid : false;
+    llmConfig.LLM === 'azure' ?
+      AZURE_API_KEY !== '' && AZURE_ENDPOINT !== '' && AZURE_DEPLOYMENT !== '' &&
+      AZURE_API_KEY !== null && AZURE_ENDPOINT !== null && AZURE_DEPLOYMENT !== null :
+      llmConfig.LLM === 'google' ?
+        GOOGLE_API_KEY !== '' && GOOGLE_API_KEY !== null && GOOGLE_API_KEY !== undefined :
+        llmConfig.LLM === 'ollama' ? isOllamaConfigValid :
+          llmConfig.LLM === 'custom' ? isCustomConfigValid : false;
 }

--- a/start.js
+++ b/start.js
@@ -29,7 +29,7 @@ const setupUserConfigFromEnv = () => {
     existingConfig = JSON.parse(fs.readFileSync(userConfigPath, 'utf8'));
   }
 
-  if (!['ollama', 'openai', 'google'].includes(existingConfig.LLM)) {
+  if (!['ollama', 'openai', 'google', 'custom', 'azure'].includes(existingConfig.LLM)) {
     existingConfig.LLM = undefined;
   }
 
@@ -44,6 +44,10 @@ const setupUserConfigFromEnv = () => {
     CUSTOM_MODEL: process.env.CUSTOM_MODEL || existingConfig.CUSTOM_MODEL,
     PEXELS_API_KEY: process.env.PEXELS_API_KEY || existingConfig.PEXELS_API_KEY,
     USE_CUSTOM_URL: process.env.USE_CUSTOM_URL || existingConfig.USE_CUSTOM_URL,
+    AZURE_OPENAI_ENDPOINT: process.env.AZURE_OPENAI_ENDPOINT || existingConfig.AZURE_OPENAI_ENDPOINT,
+    AZURE_OPENAI_API_KEY: process.env.AZURE_OPENAI_API_KEY || existingConfig.AZURE_OPENAI_API_KEY,
+    AZURE_OPENAI_DEPLOYMENT: process.env.AZURE_OPENAI_DEPLOYMENT || existingConfig.AZURE_OPENAI_DEPLOYMENT,
+    AZURE_OPENAI_API_VERSION: process.env.AZURE_OPENAI_API_VERSION || existingConfig.AZURE_OPENAI_API_VERSION,
   };
 
   fs.writeFileSync(userConfigPath, JSON.stringify(userConfig));


### PR DESCRIPTION
## Summary
- support Azure OpenAI endpoints in backend and UI
- allow Azure credentials in user config
- document Azure environment variables
- update UI to configure Azure provider

## Testing
- `pytest -q servers/fastapi/tests/test_generate_image.py` *(fails: ModuleNotFoundError: No module named 'image_processor')*

------
https://chatgpt.com/codex/tasks/task_b_6877db5ae7988321993706f5c9d10c2a